### PR TITLE
Port libll to pure Ruby; Opal support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ For more information on LL parsing, see
 | MRI      | >= 1.9.3      | >= 2.1.0    |
 | Rubinius | >= 2.2        | >= 2.5.0    |
 | JRuby    | >= 1.7        | >= 1.7.0    |
+| Opal     | >= 1.7        | >= 1.7.3    |
 | Maglev   | Not supported |             |
 | Topaz    | Not supported |             |
 | mruby    | Not supported |             |

--- a/ext/pureruby/ll/native/driver.rb
+++ b/ext/pureruby/ll/native/driver.rb
@@ -1,0 +1,116 @@
+module LL
+  class Driver
+    T_EOF = -1
+    T_RULE = 0
+    T_TERMINAL = 1
+    T_EPSILON = 2
+    T_ACTION = 3
+    T_STAR = 4
+    T_PLUS = 5
+    T_ADD_VALUE_STACK = 6
+    T_APPEND_VALUE_STACK = 7
+    T_QUESTION = 8
+
+    def config
+      self.class::CONFIG
+    end
+
+    def parse
+      stack = []
+      value_stack = []
+
+      # EOF
+      stack << T_EOF << T_EOF
+
+      # Start rule
+      start_row = config.rules_native[0]
+      stack += start_row
+
+      # Each token
+      each_token do |type, value|
+        loop do
+          if stack.empty?
+            parser_error(-1, -1, type, value)
+          end
+
+          stack_value = stack.pop
+          stack_type  = stack.pop
+          token_id    = config.terminals_native[type] || 0
+
+          # A rule or the "+" operator
+          if stack_type == T_RULE || stack_type == T_PLUS
+            production_i = config.table_native[stack_value][token_id] || T_EOF
+
+            if production_i == T_EOF
+              parser_error(stack_type, stack_value, type, value)
+            else
+              # Append a "*" operator for all following occurrences as they are optional
+              if stack_type == T_PLUS
+                stack << T_STAR << stack_value
+                stack << T_APPEND_VALUE_STACK << 0
+              end
+
+              row = config.rules_native[production_i]
+              stack += row
+            end
+          # "*" operator
+          elsif stack_type == T_STAR
+            production_i = config.table_native[stack_value][token_id] || T_EOF
+
+            if production_i != T_EOF
+              stack << T_STAR << stack_value
+              stack << T_APPEND_VALUE_STACK << 0
+
+              row = config.rules_native[production_i]
+              stack += row
+            end
+          # "?" operator
+          elsif stack_type == T_QUESTION
+            production_i = config.table_native[stack_value][token_id] || T_EOF
+
+            if production_i == T_EOF
+              value_stack << nil
+            else
+              row = config.rules_native[production_i]
+              stack += row
+            end
+          # Adds a new array to the value stack that can be used to group operator values together
+          elsif stack_type == T_ADD_VALUE_STACK
+            operator_buffer = []
+            value_stack << operator_buffer
+          # Appends the last value on the value stack to the operator buffer that precedes it.
+          elsif stack_type == T_APPEND_VALUE_STACK
+            last_value      = value_stack.pop
+            operator_buffer = value_stack.last
+            operator_buffer << last_value
+          # Terminal
+          elsif stack_type == T_TERMINAL
+            if stack_value == token_id
+              value_stack << value
+              break
+            else
+              parser_error(stack_type, stack_value, type, value)
+            end
+          # Action
+          elsif stack_type == T_ACTION
+            method = config.action_names_native[stack_value].to_s
+            num_args = config.action_arg_amounts_native[stack_value]
+            action_args = Array.new(num_args)
+
+            num_args = [num_args, value_stack.size].min
+            while num_args > 0
+              num_args -= 1
+              action_args[num_args] = value_stack.pop if value_stack.size > 0
+            end
+
+            value_stack << self.send(method, action_args)
+          elsif stack_type == T_EOF
+            break
+          end
+        end
+      end
+
+      value_stack.empty? ? nil : value_stack.pop
+    end
+  end
+end

--- a/ext/pureruby/ll/native/driver_config.rb
+++ b/ext/pureruby/ll/native/driver_config.rb
@@ -1,0 +1,48 @@
+module LL
+  class DriverConfig
+    attr_reader :terminals_native, :rules_native, :table_native,
+                :action_names_native, :action_arg_amounts_native
+
+    def initialize
+      @terminals_native = {}
+      @rules_native = []
+      @table_native = []
+      @action_names_native = []
+      @action_arg_amounts_native = []
+    end
+
+    def terminals_native=(array)
+      array.each_with_index do |sym, index|
+        @terminals_native[sym] = index
+      end
+    end
+
+    def rules_native=(array)
+      array.each do |ruby_row|
+        row = []
+        ruby_row.each do |column|
+          row << column.to_i
+        end
+        @rules_native << row
+      end
+    end
+
+    def table_native=(array)
+      array.each do |ruby_row|
+        row = []
+        ruby_row.each do |column|
+          row << column.to_i
+        end
+        @table_native << row
+      end
+    end
+
+    def actions_native=(array)
+      array.each do |row|
+        name, arity = row
+        @action_names_native << name
+        @action_arg_amounts_native << arity.to_i
+      end
+    end
+  end
+end

--- a/lib/ll/setup.rb
+++ b/lib/ll/setup.rb
@@ -3,7 +3,16 @@ require 'll/driver'
 require 'll/driver_config'
 require 'll/parser_error'
 require 'll/configuration_compiler'
-require 'libll'
+
+if RUBY_PLATFORM == 'opal'
+  require 'll/native/driver'
+  require 'll/native/driver_config'
+elsif ENV['RUBYLL_PURERUBY']
+  require_relative '../../ext/pureruby/ll/native/driver'
+  require_relative '../../ext/pureruby/ll/native/driver_config'
+else
+  require 'libll'
+end
 
 #:nocov:
 if RUBY_PLATFORM == 'java'

--- a/ruby-ll.gemspec
+++ b/ruby-ll.gemspec
@@ -44,4 +44,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'kramdown'
   s.add_development_dependency 'benchmark-ips', '~> 2.0'
   s.add_development_dependency 'rake-compiler'
+  s.add_development_dependency 'opal-rspec'
+  s.add_development_dependency 'opal-sprockets'
 end

--- a/spec/ll/code_generator_spec.rb
+++ b/spec/ll/code_generator_spec.rb
@@ -30,13 +30,15 @@ describe LL::CodeGenerator do
       @generator.generate(@config).should be_an_instance_of(String)
     end
 
-    it 'returns valid Ruby code' do
-      @tempfile.write(@generator.generate(@config))
-      @tempfile.rewind
+    unless RUBY_PLATFORM == 'opal'
+      it 'returns valid Ruby code' do
+        @tempfile.write(@generator.generate(@config))
+        @tempfile.rewind
 
-      output = `ruby -c #{@tempfile.path} 2>&1`
+        output = `ruby -c #{@tempfile.path} 2>&1`
 
-      output.should =~ /Syntax OK/
+        output.should =~ /Syntax OK/
+      end
     end
 
     it 'returns Ruby code including the inner block' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ if ENV['COVERAGE']
   require_relative 'support/simplecov'
 end
 
-require_relative '../lib/ll'
+require 'll'
 require_relative 'support/parsing'
 
 RSpec.configure do |config|

--- a/task/test.rake
+++ b/task/test.rake
@@ -2,3 +2,16 @@ desc 'Runs the tests'
 task :test => [:generate] do
   sh 'rspec spec --order random'
 end
+
+require 'opal/rspec/rake_task'
+Opal::RSpec::RakeTask.new(:"test-opal") do |_, task|
+  Opal.use_gem 'ansi'
+  Opal.append_path File.expand_path('../../lib', __FILE__)
+  Opal.append_path File.expand_path('../../ext/pureruby', __FILE__)
+
+  task.default_path = 'spec'
+  task.pattern = 'spec/**/*_spec.{rb,opal}'
+  task.runner = :node
+  task.exclude_pattern = [] # "spec/**/*nokogiri*"
+  ENV['SPEC_OPTS'] ||= "--format documentation --color"
+end


### PR DESCRIPTION
I am tasked with porting some Ruby libraries to JavaScript by using Opal (an alternative Ruby runtime, like JRuby, but targeting JavaScript runtimes). Like JRuby, it doesn't support C extensions (or Java for that matter), so I had to port the extension to pure Ruby. This implementation may be also usable to make Ruby-LL work on other Ruby runtimes, like MRuby.

I have considered porting libll directly to JavaScript, but performance is of secondary importance for the project I'm working on, but I may later revisit the idea.

In addition, I added tests for running the test suite under Opal-RSpec, so that we can be sure that Ruby-LL works under Opal.

I have made a similar patchset for Oga, but it is still a work in progress.

This PR has been sponsored by Ribose Inc. ref: plurimath/plurimath#159
