### PR TITLE
Set C standard flag to gnu2x

### DIFF
--- a/ext/c/extconf.rb
+++ b/ext/c/extconf.rb
@@ -1,7 +1,7 @@
 require 'mkmf'
 
 if RbConfig::CONFIG['CC'] =~ /clang|gcc/
-  $CFLAGS << ' -pedantic'
+  $CFLAGS << ' -pedantic' << ' -std=gnu2x'
 end
 
 if ENV['DEBUG']


### PR DESCRIPTION
Hello,

This adds `-std=gnu2x` flag to `$CFLAGS` to avoid warnings when compilation: `ISO C does not support ‘[[]]’ attributes before C2X [-Wpedantic]` (default) and `__VA_OPT__ is not available until C++20` (`-std=c2x`).

I checked that it builds with GCC 11.3.0 without warnings with this change.

Thank you,