### PR TITLE
Use typed data APIs

### DIFF
--- a/ext/c/driver.c
+++ b/ext/c/driver.c
@@ -21,8 +21,10 @@ ID id_parser_error;
  * This function is called automatically when a Driver instance is garbage
  * collected.
  */
-void ll_driver_free(DriverState *state)
+void ll_driver_free(void *data)
 {
+    DriverState *state = data;
+
     kv_destroy(state->stack);
     kv_destroy(state->value_stack);
 
@@ -33,15 +35,28 @@ void ll_driver_free(DriverState *state)
  * Marks the objects stored in the driver's internal state, preventing them from
  * being garbage collected until the next GC run.
  */
-void ll_driver_mark(DriverState *state)
+void ll_driver_mark(void *data)
 {
     size_t index;
+    DriverState *state = data;
 
     FOR(index, kv_size(state->value_stack))
     {
         rb_gc_mark(kv_A(state->value_stack, index));
     }
 }
+
+static const rb_data_type_t ll_driver_type = {
+    "LL::Driver",
+    {
+        ll_driver_mark,
+        ll_driver_free,
+        NULL,
+    },
+    NULL,
+    NULL,
+    RUBY_TYPED_FREE_IMMEDIATELY,
+};
 
 /**
  * Allocates a new instance of the Driver class and prepares its internal state.
@@ -50,18 +65,16 @@ VALUE ll_driver_allocate(VALUE klass)
 {
     DriverState *state;
     VALUE config;
-    VALUE obj = Data_Make_Struct(
+    VALUE obj = TypedData_Make_Struct(
         klass,
         DriverState,
-        ll_driver_mark,
-        ll_driver_free,
+        &ll_driver_type,
         state
     );
-    MEMZERO(state, DriverState, 1);
 
     config = rb_const_get(klass, id_config_const);
 
-    Data_Get_Struct(config, DriverConfig, state->config);
+    TypedData_Get_Struct(config, DriverConfig, &ll_driver_config_type, state->config);
 
     kv_init(state->stack);
     kv_init(state->value_stack);
@@ -110,7 +123,7 @@ VALUE ll_driver_each_token(
     VALUE type  = rb_ary_entry(token, 0);
     VALUE value = rb_ary_entry(token, 1);
 
-    Data_Get_Struct(self, DriverState, state);
+    TypedData_Get_Struct(self, DriverState, &ll_driver_type, state);
 
     while ( 1 )
     {
@@ -152,8 +165,8 @@ VALUE ll_driver_each_token(
                     self,
                     id_parser_error,
                     4,
-                    INT2NUM(stack_type),
-                    INT2NUM(stack_value),
+                    LONG2NUM(stack_type),
+                    LONG2NUM(stack_value),
                     type,
                     value
                 );
@@ -271,8 +284,8 @@ VALUE ll_driver_each_token(
                     self,
                     id_parser_error,
                     4,
-                    INT2NUM(stack_type),
-                    INT2NUM(stack_value),
+                    LONG2NUM(stack_type),
+                    LONG2NUM(stack_value),
                     type,
                     value
                 );
@@ -330,7 +343,7 @@ VALUE ll_driver_parse(VALUE self)
 
     DriverState *state;
 
-    Data_Get_Struct(self, DriverState, state);
+    TypedData_Get_Struct(self, DriverState, &ll_driver_type, state);
 
     /* EOF rule */
     kv_push(long, state->stack, T_EOF);

--- a/ext/c/driver.c
+++ b/ext/c/driver.c
@@ -48,15 +48,25 @@ void ll_driver_mark(DriverState *state)
  */
 VALUE ll_driver_allocate(VALUE klass)
 {
-    DriverState *state = ALLOC(DriverState);
-    VALUE config       = rb_const_get(klass, id_config_const);
+    DriverState *state;
+    VALUE config;
+    VALUE obj = Data_Make_Struct(
+        klass,
+        DriverState,
+        ll_driver_mark,
+        ll_driver_free,
+        state
+    );
+    MEMZERO(state, DriverState, 1);
+
+    config = rb_const_get(klass, id_config_const);
 
     Data_Get_Struct(config, DriverConfig, state->config);
 
     kv_init(state->stack);
     kv_init(state->value_stack);
 
-    return Data_Wrap_Struct(klass, ll_driver_mark, ll_driver_free, state);
+    return obj;
 }
 
 /**

--- a/ext/c/driver_config.c
+++ b/ext/c/driver_config.c
@@ -64,16 +64,18 @@ void ll_driver_config_free(DriverConfig *config)
  */
 VALUE ll_driver_config_allocate(VALUE klass)
 {
-    DriverConfig *config = ALLOC(DriverConfig);
-
-    MEMZERO(config, DriverConfig, 1);
-
-    return Data_Wrap_Struct(
+    DriverConfig *config;
+    VALUE obj = Data_Make_Struct(
         klass,
+        DriverConfig,
         ll_driver_config_mark,
         ll_driver_config_free,
         config
     );
+
+    MEMZERO(config, DriverConfig, 1);
+
+    return obj;
 }
 
 /**

--- a/ext/c/driver_config.c
+++ b/ext/c/driver_config.c
@@ -1,7 +1,9 @@
 #include "driver_config.h"
 
-void ll_driver_config_mark(DriverConfig *config)
+void ll_driver_config_mark(void *data)
 {
+    DriverConfig *config = data;
+
     if ( config->terminals != NULL )
     {
         khint_t key;
@@ -31,9 +33,10 @@ void ll_driver_config_mark(DriverConfig *config)
 /**
  * Releases memory of the DriverConfig struct and its members.
  */
-void ll_driver_config_free(DriverConfig *config)
+void ll_driver_config_free(void *data)
 {
     long rindex;
+    DriverConfig *config = data;
 
     FOR(rindex, config->rules_count)
     {
@@ -59,23 +62,30 @@ void ll_driver_config_free(DriverConfig *config)
     free(config);
 }
 
+const rb_data_type_t ll_driver_config_type = {
+    "LL::DriverConfig",
+    {
+        ll_driver_config_mark,
+        ll_driver_config_free,
+        NULL,
+    },
+    NULL,
+    NULL,
+    RUBY_TYPED_FREE_IMMEDIATELY,
+};
+
 /**
  * Allocates a new DriverConfig.
  */
 VALUE ll_driver_config_allocate(VALUE klass)
 {
     DriverConfig *config;
-    VALUE obj = Data_Make_Struct(
+    return TypedData_Make_Struct(
         klass,
         DriverConfig,
-        ll_driver_config_mark,
-        ll_driver_config_free,
+        &ll_driver_config_type,
         config
     );
-
-    MEMZERO(config, DriverConfig, 1);
-
-    return obj;
 }
 
 /**
@@ -94,7 +104,7 @@ VALUE ll_driver_config_set_terminals(VALUE self, VALUE array)
     DriverConfig *config;
     long count = RARRAY_LEN(array);
 
-    Data_Get_Struct(self, DriverConfig, config);
+    TypedData_Get_Struct(self, DriverConfig, &ll_driver_config_type, config);
 
     config->terminals = kh_init(int64_map);
 
@@ -124,7 +134,7 @@ VALUE ll_driver_config_set_rules(VALUE self, VALUE array)
     VALUE row;
     long row_count = RARRAY_LEN(array);
 
-    Data_Get_Struct(self, DriverConfig, config);
+    TypedData_Get_Struct(self, DriverConfig, &ll_driver_config_type, config);
 
     config->rules        = ALLOC_N(long*, row_count);
     config->rule_lengths = ALLOC_N(long, row_count);
@@ -164,7 +174,7 @@ VALUE ll_driver_config_set_table(VALUE self, VALUE array)
     DriverConfig *config;
     long row_count = RARRAY_LEN(array);
 
-    Data_Get_Struct(self, DriverConfig, config);
+    TypedData_Get_Struct(self, DriverConfig, &ll_driver_config_type, config);
 
     config->table = ALLOC_N(long*, row_count);
 
@@ -199,7 +209,7 @@ VALUE ll_driver_config_set_actions(VALUE self, VALUE array)
     DriverConfig *config;
     long row_count = RARRAY_LEN(array);
 
-    Data_Get_Struct(self, DriverConfig, config);
+    TypedData_Get_Struct(self, DriverConfig, &ll_driver_config_type, config);
 
     config->action_names       = ALLOC_N(VALUE, row_count);
     config->action_arg_amounts = ALLOC_N(long, row_count);

--- a/ext/c/driver_config.h
+++ b/ext/c/driver_config.h
@@ -50,4 +50,6 @@ typedef struct
 
 extern void Init_ll_driver_config();
 
+extern const rb_data_type_t ll_driver_config_type;
+
 #endif


### PR DESCRIPTION
Fix #21.
I assume this library does not support Ruby 1.8, so replaced Data macros wholly instead of switching by `#ifdef TypedData_Make_Struct`.

Note that this includes also #24.
